### PR TITLE
Add elapsed time in the tracer proxy

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -10,7 +10,23 @@ type Proxy struct {
 }
 
 type Hooks struct {
-	Open     func(conn *Conn) error
+	// PreOpen is a callback that gets called before any
+	// attempt to open the sql connection is made, and is ALWAYS
+	// called. If this callback returns an error, the underlying
+	// driver's Open() method and Hooks.Open() are not called.
+	// The first return value is passed to both Open() and PostOpen() hooks
+	PreOpen  func(name string) (interface{}, error)
+
+	// Open is only called if PreOpen() returns no error, and
+	// the underlying driver's Open() returns no error.
+	// `ctx` is the return value supplied from the PreOpen() hook
+	Open     func(ctx interface{}, conn driver.Conn) error
+
+	// PostOpen is a callback that gets called at the end of
+	// the call to Proxy.Open(). It is ALWAYS called.
+	// `ctx` is the return value supplied from the PreOpen() hook
+	PostOpen func(ctx interface{}, conn driver.Conn) error
+
 	Exec     func(stmt *Stmt, args []driver.Value, result driver.Result) error
 	Query    func(stmt *Stmt, args []driver.Value, rows driver.Rows) error
 	Begin    func(conn *Conn) error
@@ -29,21 +45,38 @@ func NewProxy(driver driver.Driver, hooks *Hooks) *Proxy {
 }
 
 func (p *Proxy) Open(name string) (driver.Conn, error) {
-	conn, err := p.Driver.Open(name)
+	var err error
+	var ctx interface{}
+
+	var conn driver.Conn
+	if h := p.Hooks.PostOpen; h != nil {
+		// Setup PostOpen. This needs to be a closure like this
+		// or otherwise changes to the `ctx` and `conn` parameters
+		// within this Open() method does not get applied at the
+		// time defer is fired
+		defer func() { h(ctx, conn) }()
+	}
+
+	if h := p.Hooks.PreOpen; h != nil {
+		if ctx, err = h(name); err != nil {
+			return nil, err
+		}
+	}
+	conn, err = p.Driver.Open(name)
 	if err != nil {
 		return nil, err
 	}
 
-	proxyConn := &Conn{
+	conn = &Conn{
 		Conn:  conn,
 		Proxy: p,
 	}
+
 	if hook := p.Hooks.Open; hook != nil {
-		if err := hook(proxyConn); err != nil {
+		if err = hook(ctx, conn); err != nil {
 			conn.Close()
 			return nil, err
 		}
 	}
-
-	return proxyConn, nil
+	return conn, nil
 }

--- a/proxy.go
+++ b/proxy.go
@@ -12,22 +12,68 @@ type Proxy struct {
 type Hooks struct {
 	// PreOpen is a callback that gets called before any
 	// attempt to open the sql connection is made, and is ALWAYS
-	// called. If this callback returns an error, the underlying
-	// driver's Open() method and Hooks.Open() are not called.
-	// The first return value is passed to both Open() and PostOpen() hooks
-	PreOpen  func(name string) (interface{}, error)
+	// called.
+	//
+	// The first return value is passed to both `Hooks.Open` and
+	// `Hooks.PostOpen` callbacks. You may specify anything you want.
+	// Return nil if you do not need to use it.
+	//
+	// The second return value is indicates the error found while
+	// executing this hook. If this callback returns an error,
+	// the underlying driver's `Driver.Open` method and `Hooks.Open`
+	// methods are not called.
+	PreOpen func(name string) (interface{}, error)
 
-	// Open is only called if PreOpen() returns no error, and
-	// the underlying driver's Open() returns no error.
-	// `ctx` is the return value supplied from the PreOpen() hook
-	Open     func(ctx interface{}, conn driver.Conn) error
+	// Open is called after the underlying driver's `Driver.Open` method
+	// returns without any errors.
+	//
+	// The `ctx` parameter is the return value supplied from the
+	// `Hooks.PreOpen` method, and may be nil.
+	//
+	// If this callback returns an error, then the `conn` object is
+	// closed by calling the `Close` method, and the error from this
+	// callback is returned by the `db.Open` method.
+	Open func(ctx interface{}, conn driver.Conn) error
 
 	// PostOpen is a callback that gets called at the end of
-	// the call to Proxy.Open(). It is ALWAYS called.
-	// `ctx` is the return value supplied from the PreOpen() hook
+	// the call to `db.Open(). It is ALWAYS called.
+	//
+	// The `ctx` parameter is the return value supplied from the
+	// `Hooks.PreOpen` method, and may be nil.
 	PostOpen func(ctx interface{}, conn driver.Conn) error
 
-	Exec     func(stmt *Stmt, args []driver.Value, result driver.Result) error
+	// PreExec is a callback that gets called prior to calling
+	// `Stmt.Exec`, and is ALWAYS called. If this callback returns an
+	// error, the underlying driver's `Stmt.Exec` and `Hooks.Open` methods
+	// are not called.
+	//
+	// The first return value is passed to both `Hooks.Exec` and
+	// `Hooks.PostExec` callbacks. You may specify anything you want.
+	// Return nil if you do not need to use it.
+	//
+	// The second return value is indicates the error found while
+	// executing this hook. If this callback returns an error,
+	// the underlying driver's `Driver.Exec` method and `Hooks.Exec`
+	// methods are not called.
+	PreExec func(stmt *Stmt, args []driver.Value) (interface{}, error)
+
+	// Exec is called after the underlying driver's `Driver.Exec` method
+	// returns without any errors.
+	//
+	// The `ctx` parameter is the return value supplied from the
+	// `Hooks.PreExec` method, and may be nil.
+	//
+	// If this callback returns an error, then the error from this
+	// callback is returned by the `Stmt.Exec` method.
+	Exec func(ctx interface{}, stmt *Stmt, args []driver.Value, result driver.Result) error
+
+	// PostExec is a callback that gets called at the end of
+	// the call to `Stmt.Exec`. It is ALWAYS called.
+	//
+	// The `ctx` parameter is the return value supplied from the
+	// `Hooks.PreExec` method, and may be nil.
+	PostExec func(ctx interface{}, stmt *Stmt, args []driver.Value, result driver.Result) error
+
 	Query    func(stmt *Stmt, args []driver.Value, rows driver.Rows) error
 	Begin    func(conn *Conn) error
 	Commit   func(tx *Tx) error

--- a/tracer.go
+++ b/tracer.go
@@ -11,7 +11,7 @@ func NewTraceProxy(d driver.Driver, logger *log.Logger) *Proxy {
 	return &Proxy{
 		Driver: d,
 		Hooks: &Hooks{
-			Open: func(conn *Conn) error {
+			Open: func(_ interface{}, _ driver.Conn) error {
 				logger.Output(6, "Open")
 				return nil
 			},

--- a/tracer.go
+++ b/tracer.go
@@ -19,7 +19,7 @@ func NewTraceProxy(d driver.Driver, logger *log.Logger) *Proxy {
 				logger.Output(6, fmt.Sprintf("Exec: %s; args = %v", stmt.QueryString, args))
 				return nil
 			},
-			Query: func(stmt *Stmt, args []driver.Value, rows driver.Rows) error {
+			Query: func(_ interface{}, stmt *Stmt, args []driver.Value, rows driver.Rows) error {
 				logger.Output(8, fmt.Sprintf("Query: %s; args = %v", stmt.QueryString, args))
 				return nil
 			},

--- a/tracer.go
+++ b/tracer.go
@@ -15,7 +15,7 @@ func NewTraceProxy(d driver.Driver, logger *log.Logger) *Proxy {
 				logger.Output(6, "Open")
 				return nil
 			},
-			Exec: func(stmt *Stmt, args []driver.Value, result driver.Result) error {
+			Exec: func(_ interface{}, stmt *Stmt, args []driver.Value, result driver.Result) error {
 				logger.Output(6, fmt.Sprintf("Exec: %s; args = %v", stmt.QueryString, args))
 				return nil
 			},

--- a/tracer.go
+++ b/tracer.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"log"
+	"time"
 )
 
 // NewTraceProxy generates a proxy that logs queries.
@@ -11,16 +12,47 @@ func NewTraceProxy(d driver.Driver, logger *log.Logger) *Proxy {
 	return &Proxy{
 		Driver: d,
 		Hooks: &Hooks{
-			Open: func(_ interface{}, _ driver.Conn) error {
-				logger.Output(6, "Open")
+			PreOpen: func(_ string) (interface{}, error) {
+				return time.Now(), nil
+			},
+			PostOpen: func(ctx interface{}, _ driver.Conn) error {
+				logger.Output(
+					7,
+					fmt.Sprintf(
+						"Open (%s)",
+						time.Since(ctx.(time.Time)),
+					),
+				)
 				return nil
 			},
-			Exec: func(_ interface{}, stmt *Stmt, args []driver.Value, result driver.Result) error {
-				logger.Output(6, fmt.Sprintf("Exec: %s; args = %v", stmt.QueryString, args))
+			PreExec: func(stmt *Stmt, args []driver.Value) (interface{}, error) {
+				return time.Now(), nil
+			},
+			PostExec: func(ctx interface{}, stmt *Stmt, args []driver.Value, _ driver.Result) error {
+				logger.Output(
+					7,
+					fmt.Sprintf(
+						"Exec: %s; args = %v (%s)",
+						stmt.QueryString,
+						args,
+						time.Since(ctx.(time.Time)),
+					),
+				)
 				return nil
 			},
-			Query: func(_ interface{}, stmt *Stmt, args []driver.Value, rows driver.Rows) error {
-				logger.Output(8, fmt.Sprintf("Query: %s; args = %v", stmt.QueryString, args))
+			PreQuery: func(stmt *Stmt, args []driver.Value) (interface{}, error) {
+				return time.Now(), nil
+			},
+			PostQuery: func(ctx interface{}, stmt *Stmt, args []driver.Value, _ driver.Rows) error {
+				logger.Output(
+					9,
+					fmt.Sprintf(
+						"Query: %s; args = %v (%s)",
+						stmt.QueryString,
+						args,
+						time.Since(ctx.(time.Time)),
+					),
+				)
 				return nil
 			},
 			Begin: func(conn *Conn) error {


### PR DESCRIPTION
refs #2

This change implements Pre/Post hook points for Open/Exec/Query hooks, and uses those to record additional information about elapsed time to execute each operation.