### PR TITLE
Improve tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ db, err := sql.Open("another:tracer", dataSourceName)
 ```
 
 `proxy.RegisterTracer` is a shortcut to `proxy.NewTraceProxy` and `sql.Register`.
+You can use it if your Go is from version 1.5 onward.
 
 ``` go
 proxy.RegisterTracer()

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 A proxy package is a proxy driver for dabase/sql.
 You can hook SQL execution.
 
+## SYNOPSIS
+
+### Basic Usage
+
 First, register new proxy driver.
 
 ``` go
@@ -20,8 +24,27 @@ And then, open new database handle with the registered proxy driver.
 db, err := sql.Open("new-proxy-name", dataSourceName)
 ```
 
+### Use Ready‐Made SQL tracer
 
-# EXAMPLE: SQL tracer
+`proxy.NewTraceProxy` is an example of SQL tracer.
+
+``` go
+logger := New(os.Stderr, "", LstdFlags)
+proxy := NewTraceProxy(&another.Driver{}, logger)
+sql.Register("another:tracer", proxy)
+db, err := sql.Open("another:tracer", dataSourceName)
+```
+
+`proxy.RegisterTracer` is a shortcut to `proxy.NewTraceProxy` and `sql.Register`.
+
+``` go
+proxy.RegisterTracer()
+db, err := sql.Open("another:tracer", dataSourceName)
+```
+
+## EXAMPLES
+
+### EXAMPLE: SQL tracer
 
 ``` go
 package main
@@ -79,7 +102,7 @@ func main() {
 }
 ```
 
-# EXAMPLE: elapsed time logger
+### EXAMPLE: elapsed time logger
 
 ``` go
 package main
@@ -123,7 +146,7 @@ func main() {
 ```
 
 
-# LICENSE
+## LICENSE
 
 This software is released under the MIT License, see LICENSE file.
 

--- a/tracer.go
+++ b/tracer.go
@@ -1,20 +1,12 @@
 package proxy
 
 import (
-	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"log"
 	"runtime"
 	"strings"
 	"time"
 )
-
-type logger struct{}
-
-func (_ logger) Output(calldepth int, s string) error {
-	return log.Output(calldepth, s)
-}
 
 // Outputter is what is used by the tracing proxy created via `NewTraceProxy`.
 // Anything that implements a `log.Logger` style `Output` method will satisfy
@@ -154,19 +146,5 @@ func NewTraceProxyWithFilter(d driver.Driver, o Outputter, f Filter) *Proxy {
 				return nil
 			},
 		},
-	}
-}
-
-// RegisterTracer creates proxies that logs queries from the sql drivers already registered,
-// and registers the proxies as sql driver.
-// The proxies' names have suffix ":trace".
-func RegisterTracer() {
-	for _, driver := range sql.Drivers() {
-		if strings.HasSuffix(driver, ":trace") {
-			continue
-		}
-		db, _ := sql.Open(driver, "")
-		defer db.Close()
-		sql.Register(driver+":trace", NewTraceProxy(db.Driver(), logger{}))
 	}
 }

--- a/tracer.go
+++ b/tracer.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -12,7 +13,7 @@ import (
 type logger struct{}
 
 func (_ logger) Output(calldepth int, s string) error {
-	log.Output(calldepth, s)
+	return log.Output(calldepth, s)
 }
 
 // Outputter is what is used by the tracing proxy created via `NewTraceProxy`.
@@ -22,8 +23,60 @@ type Outputter interface {
 	Output(calldepth int, s string) error
 }
 
+type Filter interface {
+	DoOutput(packageName string) bool
+}
+
+type PackageFilter map[string]struct{}
+
+func (f PackageFilter) DoOutput(packageName string) bool {
+	_, ok := f[packageName]
+	return !ok
+}
+
+func (f PackageFilter) Ignore(packageName string) {
+	f[packageName] = struct{}{}
+}
+
+func findCaller(f Filter) int {
+	// i starts 4. 0: findCaller, 1: hooks, 2: proxy-funcs, 3: database/sql, and equals or greater than 4: user-funcs
+	for i := 4; ; i++ {
+		pc, _, _, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+
+		// http://stackoverflow.com/questions/25262754/how-to-get-name-of-current-package-in-go
+		parts := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+		pl := len(parts)
+		packageName := ""
+		if parts[pl-2][0] == '(' {
+			packageName = strings.Join(parts[0:pl-2], ".")
+		} else {
+			packageName = strings.Join(parts[0:pl-1], ".")
+		}
+
+		if f.DoOutput(packageName) {
+			return i
+		}
+	}
+	return 0
+}
+
 // NewTraceProxy generates a proxy that logs queries.
 func NewTraceProxy(d driver.Driver, o Outputter) *Proxy {
+	return NewTraceProxyWithFilter(d, o, nil)
+}
+
+// NewTraceProxyWithFilter generates a proxy that logs queries.
+func NewTraceProxyWithFilter(d driver.Driver, o Outputter, f Filter) *Proxy {
+	if f == nil {
+		f = PackageFilter{
+			"database/sql":                    struct{}{},
+			"github.com/shogo82148/txmanager": struct{}{},
+		}
+	}
+
 	return &Proxy{
 		Driver: d,
 		Hooks: &Hooks{
@@ -32,7 +85,7 @@ func NewTraceProxy(d driver.Driver, o Outputter) *Proxy {
 			},
 			PostOpen: func(ctx interface{}, _ driver.Conn) error {
 				o.Output(
-					7,
+					findCaller(f),
 					fmt.Sprintf(
 						"Open (%s)",
 						time.Since(ctx.(time.Time)),
@@ -45,7 +98,7 @@ func NewTraceProxy(d driver.Driver, o Outputter) *Proxy {
 			},
 			PostExec: func(ctx interface{}, stmt *Stmt, args []driver.Value, _ driver.Result) error {
 				o.Output(
-					7,
+					findCaller(f),
 					fmt.Sprintf(
 						"Exec: %s; args = %v (%s)",
 						stmt.QueryString,
@@ -60,7 +113,7 @@ func NewTraceProxy(d driver.Driver, o Outputter) *Proxy {
 			},
 			PostQuery: func(ctx interface{}, stmt *Stmt, args []driver.Value, _ driver.Rows) error {
 				o.Output(
-					9,
+					findCaller(f),
 					fmt.Sprintf(
 						"Query: %s; args = %v (%s)",
 						stmt.QueryString,
@@ -75,7 +128,7 @@ func NewTraceProxy(d driver.Driver, o Outputter) *Proxy {
 			},
 			PostBegin: func(ctx interface{}, _ *Conn) error {
 				o.Output(
-					6,
+					findCaller(f),
 					fmt.Sprintf("Begin (%s)", time.Since(ctx.(time.Time))),
 				)
 				return nil
@@ -85,7 +138,7 @@ func NewTraceProxy(d driver.Driver, o Outputter) *Proxy {
 			},
 			PostCommit: func(ctx interface{}, _ *Tx) error {
 				o.Output(
-					7,
+					findCaller(f),
 					fmt.Sprintf("Commit (%s)", time.Since(ctx.(time.Time))),
 				)
 				return nil
@@ -95,7 +148,7 @@ func NewTraceProxy(d driver.Driver, o Outputter) *Proxy {
 			},
 			PostRollback: func(ctx interface{}, _ *Tx) error {
 				o.Output(
-					8,
+					findCaller(f),
 					fmt.Sprintf("Rollback (%s)", time.Since(ctx.(time.Time))),
 				)
 				return nil

--- a/tracer_register.go
+++ b/tracer_register.go
@@ -1,0 +1,29 @@
+// +build go1.5
+
+package proxy
+
+import (
+	"database/sql"
+	"log"
+	"strings"
+)
+
+type logger struct{}
+
+func (_ logger) Output(calldepth int, s string) error {
+	return log.Output(calldepth, s)
+}
+
+// RegisterTracer creates proxies that logs queries from the sql drivers already registered,
+// and registers the proxies as sql driver.
+// The proxies' names have suffix ":trace".
+func RegisterTracer() {
+	for _, driver := range sql.Drivers() {
+		if strings.HasSuffix(driver, ":trace") {
+			continue
+		}
+		db, _ := sql.Open(driver, "")
+		defer db.Close()
+		sql.Register(driver+":trace", NewTraceProxy(db.Driver(), logger{}))
+	}
+}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -52,11 +52,8 @@ func TestTraceProxy(t *testing.T) {
 		// Fake time compinent with (\d+\.\d+[^\)]+)
 		regexp.MustCompile(`tracer_test.go:27: Open ` + timeComponent),
 		regexp.MustCompile(`tracer_test.go:27: Exec: CREATE TABLE t1 \(id INTEGER PRIMARY KEY\); args = \[\] ` + timeComponent),
-		// The line numbers on these two lines may change depending on the version
-		// of txmanager that you have. For now, we cross our fingers that the
-		// filename doesn't change ever, but the line numbers may change.
-		regexp.MustCompile(`txmanager.go:\d+: Begin ` + timeComponent),
-		regexp.MustCompile(`txmanager.go:\d+: Exec: INSERT INTO t1 \(id\) VALUES\(\?\); args = \[1\] ` + timeComponent),
+		regexp.MustCompile(`tracer_test.go:36: Begin ` + timeComponent),
+		regexp.MustCompile(`tracer_test.go:34: Exec: INSERT INTO t1 \(id\) VALUES\(\?\); args = \[1\] ` + timeComponent),
 		regexp.MustCompile(`tracer_test.go:36: Commit ` + timeComponent),
 		regexp.MustCompile(`tracer_test.go:41: Query: SELECT id FROM t1 WHERE id = \?; args = \[1\] ` + timeComponent),
 	}


### PR DESCRIPTION
- add `NewTraceProxyWithFilter` and `PackageFilter`

``` go
logger := New(os.Stderr, "", log.LstdFlags)
filter := proxy.PackageFilter{}
filter.Ignore("github.com/naoina/genmai")
proxy := NewTraceProxyWithFilter(logger, filter)
```

- add `RegisterTracer` (go 1.5 or above)

A shortcut to `proxy.NewTraceProxy` and `sql.Register`.

``` go
proxy.RegisterTracer()
db, err := sql.Open("another:tracer", dataSourceName)
```