### PR TITLE
Support optionals

### DIFF
--- a/stmt.go
+++ b/stmt.go
@@ -73,3 +73,10 @@ func (stmt *Stmt) Query(args []driver.Value) (driver.Rows, error) {
 
 	return rows, nil
 }
+
+func (stmt *Stmt) ColumnConverter(idx int) driver.ValueConverter {
+	if conv, ok := stmt.Stmt.(driver.ColumnConverter); ok {
+		return conv.ColumnConverter(idx)
+	}
+	return driver.DefaultParameterConverter
+}


### PR DESCRIPTION
fix https://github.com/shogo82148/go-sql-proxy/issues/8

I implemented some optionally interfaces.

https://golang.org/pkg/database/sql/driver/#ColumnConverter
> ColumnConverter may be optionally implemented by Stmt if the statement is aware of its own columns' types and can convert from any type to a driver Value.

https://golang.org/pkg/database/sql/driver/#Execer
> Execer is an optional interface that may be implemented by a Conn.

https://golang.org/pkg/database/sql/driver/#Queryer
> Queryer is an optional interface that may be implemented by a Conn.
