### PR TITLE
fix #16 use runtime.CallersFrames instead of runtime.FuncForPC

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -295,11 +295,19 @@ func findCaller(f Filter) int {
 	skip := 5
 	for {
 		var rpc [8]uintptr
+		var i int
 		n := runtime.Callers(skip, rpc[:])
-
-		for i, pc := range rpc[:n] {
+		frames := runtime.CallersFrames(rpc[:])
+		for i = 0; ; i++ {
+			frame, more := frames.Next()
+			if !more {
+				break
+			}
+			name := frame.Function
+			if name == "" {
+				continue
+			}
 			// http://stackoverflow.com/questions/25262754/how-to-get-name-of-current-package-in-go
-			name := runtime.FuncForPC(pc).Name()
 			dotIdx := 0
 			for j := len(name) - 1; j >= 0; j-- {
 				if name[j] == '.' {
@@ -317,7 +325,7 @@ func findCaller(f Filter) int {
 		if n < len(rpc) {
 			break
 		}
-		skip += n
+		skip += i
 	}
 	return 0
 }


### PR DESCRIPTION
I try to fix it by https://github.com/shogo82148/go-sql-proxy/pull/19, but it doesn't work in Go 1.12 beta1.

before:

```
=== RUN   TestTraceProxy
--- FAIL: TestTraceProxy (0.00s)
    tracer_go110_test.go:80: sql.go:1439: Open 0xc00009cc60 (778.869µs)
    tracer_go110_test.go:87:
        got: sql.go:1439: Open 0xc00009cc60 (778.869µs)
        want: tracer_go110_test.go:\d+: Open 0x[0-9a-f]+ \(\d+(?:\.\d+)?[^\)]+\)
    tracer_go110_test.go:80: sql.go:1439: Exec 0xc00009cc60: CREATE TABLE t1 (id INTEGER PRIMARY KEY); args = [] (375.614µs)
    tracer_go110_test.go:87:
        got: sql.go:1439: Exec 0xc00009cc60: CREATE TABLE t1 (id INTEGER PRIMARY KEY); args = [] (375.614µs)
        want: tracer_go110_test.go:\d+: Exec 0x[0-9a-f]+: CREATE TABLE t1 \(id INTEGER PRIMARY KEY\); args = \[\] \(\d+(?:\.\d+)?[^\)]+\)
    tracer_go110_test.go:80: asm_amd64.s:1337: ResetSession 0xc00009cc60 (4.938µs)
    tracer_go110_test.go:80: txmanager.go:181: Begin 0xc00009cc60 (35.386µs)
    tracer_go110_test.go:87:
        got: txmanager.go:181: Begin 0xc00009cc60 (35.386µs)
        want: tracer_go110_test.go:\d+: Begin 0x[0-9a-f]+ \(\d+(?:\.\d+)?[^\)]+\)
    tracer_go110_test.go:80: tracer_go110_test.go:39: Exec 0xc00009cc60: INSERT INTO t1 (id) VALUES(?); args = [1] (122.064µs)
    tracer_go110_test.go:80: tracer_go110_test.go:38: Commit 0xc00009cc60 (25.291µs)
    tracer_go110_test.go:80: asm_amd64.s:1337: ResetSession 0xc00009cc60 (980ns)
    tracer_go110_test.go:80: tracer_go110_test.go:46: Query 0xc00009cc60: SELECT id FROM t1 WHERE id = ?; args = [1] (41.68µs)
    tracer_go110_test.go:80: asm_amd64.s:1337: ResetSession 0xc00009cc60 (1.15µs)
    tracer_go110_test.go:80: tracer_go110_test.go:55: Exec 0xc00009cc60: ILLEGAL SQL; args = []; err = "near \"ILLEGAL\": syntax error" (14.024µs)
    tracer_go110_test.go:80: asm_amd64.s:1337: ResetSession 0xc00009cc60 (4.389µs)
FAIL
FAIL	github.com/shogo82148/go-sql-proxy	0.017s
```

after:

```
=== RUN   TestTraceProxy
--- PASS: TestTraceProxy (0.00s)
    tracer_go110_test.go:80: tracer_go110_test.go:30: Open 0xc000078c60 (685.616µs)
    tracer_go110_test.go:80: tracer_go110_test.go:30: Exec 0xc000078c60: CREATE TABLE t1 (id INTEGER PRIMARY KEY); args = [] (204.524µs)
    tracer_go110_test.go:80: asm_amd64.s:1337: ResetSession 0xc000078c60 (1.718µs)
    tracer_go110_test.go:80: tracer_go110_test.go:38: Begin 0xc000078c60 (12.31µs)
    tracer_go110_test.go:80: tracer_go110_test.go:39: Exec 0xc000078c60: INSERT INTO t1 (id) VALUES(?); args = [1] (40.299µs)
    tracer_go110_test.go:80: tracer_go110_test.go:38: Commit 0xc000078c60 (8.834µs)
    tracer_go110_test.go:80: asm_amd64.s:1337: ResetSession 0xc000078c60 (502ns)
    tracer_go110_test.go:80: tracer_go110_test.go:46: Query 0xc000078c60: SELECT id FROM t1 WHERE id = ?; args = [1] (13.925µs)
    tracer_go110_test.go:80: asm_amd64.s:1337: ResetSession 0xc000078c60 (519ns)
    tracer_go110_test.go:80: tracer_go110_test.go:55: Exec 0xc000078c60: ILLEGAL SQL; args = []; err = "near \"ILLEGAL\": syntax error" (5.922µs)
    tracer_go110_test.go:80: asm_amd64.s:1337: ResetSession 0xc000078c60 (789ns)
PASS
ok  	github.com/shogo82148/go-sql-proxy	(cached)
```