### PR TITLE
Update readme 2020 07 29

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,4 +202,4 @@ This software is released under the MIT License, see LICENSE file.
 
 ## godoc
 
-See [godoc](https://godoc.org/github.com/shogo82148/go-sql-proxy) for more information.
+See [godoc](https://pkg.go.dev/github.com/shogo82148/go-sql-proxy?tab=doc) for more information.


### PR DESCRIPTION
Migrate the link from godoc.org to pkg.go.dev