### PR TITLE
migrate `set-env` command to file commands

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
         id: go
       - run: |
           go version
-          echo ::set-env name=GOPATH::$GITHUB_WORKSPACE
+          echo GOPATH="$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
GitHub Actions: Deprecating set-env and add-path commands
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/