### PR TITLE
pass stmt.QueryString to QueryContext and ExecContext calls

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -256,7 +256,7 @@ func (conn *Conn) QueryContext(c context.Context, query string, args []driver.Na
 	var rows driver.Rows
 	hooks := conn.Proxy.getHooks(c)
 	if hooks != nil {
-		stmt := &Stmt{
+		stmt = &Stmt{
 			QueryString: query,
 			Proxy:       conn.Proxy,
 			Conn:        conn,


### PR DESCRIPTION
This is to allow pre-rewriting by hooks.

What I want to do with this is to embed comments in the publish query, just like Teng and DBIx::Sunny in Perl.

It may be necessary to handle `Prepare` as well, but I'm not doing so at present.

There may be a little overhead because the assignment to `stmt` is always made for each invocation. What do you think?