### PR TITLE
migrate to Codecov GitHub Action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,11 +59,12 @@ jobs:
           working-directory: src/github.com/shogo82148/go-sql-proxy
           flag-name: ${{ matrix.os }}-Go-${{ matrix.go }}
       - name: Send coverage to codecov.io
-        run: bash <(curl -s https://codecov.io/bash)
-        shell: bash
+        uses: codecov/codecov-action@v1
+        with:
+          env_vars: OS,GO
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        working-directory: src/github.com/shogo82148/go-sql-proxy
+          OS: ${{ matrix.os }}
+          GO: ${{ matrix.go }}
   finish:
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Recently, Codecov experienced a security incident involving its bash uploader.
https://about.codecov.io/security-update/
For that reason, new Uploader will come and the bash uploader will be deprecated.
https://about.codecov.io/blog/introducing-codecovs-new-uploader/