### PR TITLE
Connector implements io.Closer

### DIFF
--- a/connector_test.go
+++ b/connector_test.go
@@ -4,9 +4,63 @@
 package proxy
 
 import (
+	"context"
 	"database/sql/driver"
+	"errors"
 	"io"
+	"testing"
 )
 
 var _ io.Closer = (*Connector)(nil)
 var _ driver.Connector = (*Connector)(nil)
+
+var _ io.Closer = (*closerConnector)(nil)
+var _ driver.Connector = (*closerConnector)(nil)
+
+type closerConnector struct {
+	// the result of Close() method
+	errClose error
+
+	// a flag whether Close() method is called
+	closed bool
+}
+
+func (c *closerConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	panic("never used")
+}
+
+func (c *closerConnector) Driver() driver.Driver {
+	return fdriverctx
+}
+
+func (c *closerConnector) Close() error {
+	c.closed = true
+	return c.errClose
+}
+
+func TestConnectorClose(t *testing.T) {
+	t.Run("Closing c.Connector succeeds", func(t *testing.T) {
+		c0 := &closerConnector{}
+		c1 := NewConnector(c0)
+		if err := c1.(io.Closer).Close(); err != nil {
+			t.Fatal(err)
+		}
+		if !c0.closed {
+			t.Errorf("c.Connector should be closed, but not")
+		}
+	})
+
+	t.Run("Closing c.Connector fails", func(t *testing.T) {
+		errClose := errors.New("some error while closing")
+		c0 := &closerConnector{
+			errClose: errClose,
+		}
+		c1 := NewConnector(c0)
+		if err := c1.(io.Closer).Close(); err != errClose {
+			t.Errorf("want err is %v, got %v", errClose, err)
+		}
+		if !c0.closed {
+			t.Errorf("c.Connector should be closed, but not")
+		}
+	})
+}

--- a/connector_test.go
+++ b/connector_test.go
@@ -39,6 +39,16 @@ func (c *closerConnector) Close() error {
 }
 
 func TestConnectorClose(t *testing.T) {
+	t.Run("c.Connector doesn't implement io.Closer", func(t *testing.T) {
+		c0 := &fakeConnector{
+			driver: &fakeDriverCtx{},
+		}
+		c1 := NewConnector(c0)
+		if err := c1.(io.Closer).Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
 	t.Run("Closing c.Connector succeeds", func(t *testing.T) {
 		c0 := &closerConnector{}
 		c1 := NewConnector(c0)

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,3 +1,6 @@
+//go:build go1.10
+// +build go1.10
+
 package proxy
 
 import (

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,0 +1,9 @@
+package proxy
+
+import (
+	"database/sql/driver"
+	"io"
+)
+
+var _ io.Closer = (*Connector)(nil)
+var _ driver.Connector = (*Connector)(nil)


### PR DESCRIPTION
from Go 1.17, the DB.Close method  closes the connector field.

> https://tip.golang.org/doc/go1.17#database/sql
> The DB.Close method now closes the connector field if the type in this field implements the io.Closer interface.

> https://tip.golang.org/pkg/database/sql/driver/#Connector
> If a Connector implements io.Closer, the sql package's DB.Close method will call Close and return error (if any).