### PR TITLE
bump codecov/codecov-action@v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,10 @@ jobs:
           - "1.9"
           - "1.8"
 
+    env:
+      OS: ${{ matrix.os }}
+      GO: ${{ matrix.go }}
+
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v2
@@ -59,7 +63,7 @@ jobs:
           working-directory: src/github.com/shogo82148/go-sql-proxy
           flag-name: ${{ matrix.os }}-Go-${{ matrix.go }}
       - name: Send coverage to codecov.io
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           env_vars: OS,GO
           root_dir: src/github.com/shogo82148/go-sql-proxy

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,10 +28,6 @@ jobs:
           - "1.9"
           - "1.8"
 
-    env:
-      OS: ${{ matrix.os }}
-      GO: ${{ matrix.go }}
-
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v2


### PR DESCRIPTION
`codecov/codecov-action@v2` is released and v2 is now deprecated.

> https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1
> Deprecration of v1
> On February 1, 2022, this version will be fully sunset and no longer function
> 
> Due to the deprecation of the underlying bash uploader, the Codecov GitHub Action has released v2 which will use the new uploader. You can learn more about our deprecation plan and the new uploader on our blog.
> 
> We will be restricting any updates to the v1 Action to security updates and hotfixes.

We should migrate from v1 to v2.