### PR TITLE
Adding capabilities to change the error returned by the driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/shogo82148/go-sql-proxy
+module github.com/cdleo/go-sql-proxy
 
 go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/cdleo/go-sql-proxy
+module github.com/shogo82148/go-sql-proxy
 
 go 1.17

--- a/hooks.go
+++ b/hooks.go
@@ -412,7 +412,7 @@ func (h *HooksContext) ping(c context.Context, ctx interface{}, conn *Conn) erro
 
 func (h *HooksContext) postPing(c context.Context, ctx interface{}, conn *Conn, err error) error {
 	if h == nil || h.PostPing == nil {
-		return nil
+		return err
 	}
 	return h.PostPing(c, ctx, conn, err)
 }
@@ -433,7 +433,7 @@ func (h *HooksContext) open(c context.Context, ctx interface{}, conn *Conn) erro
 
 func (h *HooksContext) postOpen(c context.Context, ctx interface{}, conn *Conn, err error) error {
 	if h == nil || h.PostOpen == nil {
-		return nil
+		return err
 	}
 	return h.PostOpen(c, ctx, conn, err)
 }
@@ -454,7 +454,7 @@ func (h *HooksContext) prepare(c context.Context, ctx interface{}, stmt *Stmt) e
 
 func (h *HooksContext) postPrepare(c context.Context, ctx interface{}, stmt *Stmt, err error) error {
 	if h == nil || h.PostPrepare == nil {
-		return nil
+		return err
 	}
 	return h.PostPrepare(c, ctx, stmt, err)
 }
@@ -475,7 +475,7 @@ func (h *HooksContext) exec(c context.Context, ctx interface{}, stmt *Stmt, args
 
 func (h *HooksContext) postExec(c context.Context, ctx interface{}, stmt *Stmt, args []driver.NamedValue, result driver.Result, err error) error {
 	if h == nil || h.PostExec == nil {
-		return nil
+		return err
 	}
 	return h.PostExec(c, ctx, stmt, args, result, err)
 }
@@ -496,7 +496,7 @@ func (h *HooksContext) query(c context.Context, ctx interface{}, stmt *Stmt, arg
 
 func (h *HooksContext) postQuery(c context.Context, ctx interface{}, stmt *Stmt, args []driver.NamedValue, rows driver.Rows, err error) error {
 	if h == nil || h.PostQuery == nil {
-		return nil
+		return err
 	}
 	return h.PostQuery(c, ctx, stmt, args, rows, err)
 }
@@ -517,7 +517,7 @@ func (h *HooksContext) begin(c context.Context, ctx interface{}, conn *Conn) err
 
 func (h *HooksContext) postBegin(c context.Context, ctx interface{}, conn *Conn, err error) error {
 	if h == nil || h.PostBegin == nil {
-		return nil
+		return err
 	}
 	return h.PostBegin(c, ctx, conn, err)
 }
@@ -538,7 +538,7 @@ func (h *HooksContext) commit(c context.Context, ctx interface{}, tx *Tx) error 
 
 func (h *HooksContext) postCommit(c context.Context, ctx interface{}, tx *Tx, err error) error {
 	if h == nil || h.PostCommit == nil {
-		return nil
+		return err
 	}
 	return h.PostCommit(c, ctx, tx, err)
 }
@@ -559,7 +559,7 @@ func (h *HooksContext) rollback(c context.Context, ctx interface{}, tx *Tx) erro
 
 func (h *HooksContext) postRollback(c context.Context, ctx interface{}, tx *Tx, err error) error {
 	if h == nil || h.PostRollback == nil {
-		return nil
+		return err
 	}
 	return h.PostRollback(c, ctx, tx, err)
 }
@@ -580,7 +580,7 @@ func (h *HooksContext) close(c context.Context, ctx interface{}, conn *Conn) err
 
 func (h *HooksContext) postClose(c context.Context, ctx interface{}, conn *Conn, err error) error {
 	if h == nil || h.PostClose == nil {
-		return nil
+		return err
 	}
 	return h.PostClose(c, ctx, conn, err)
 }
@@ -601,7 +601,7 @@ func (h *HooksContext) resetSession(c context.Context, ctx interface{}, conn *Co
 
 func (h *HooksContext) postResetSession(c context.Context, ctx interface{}, conn *Conn, err error) error {
 	if h == nil || h.PostResetSession == nil {
-		return nil
+		return err
 	}
 	return h.PostResetSession(c, ctx, conn, err)
 }

--- a/logging_hook_test.go
+++ b/logging_hook_test.go
@@ -37,7 +37,7 @@ func (h *loggingHook) postPing(c context.Context, ctx interface{}, conn *Conn, e
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	fmt.Fprintln(h, "[PostPing]")
-	return nil
+	return err
 }
 
 func (h *loggingHook) preOpen(c context.Context, name string) (interface{}, error) {
@@ -58,7 +58,7 @@ func (h *loggingHook) postOpen(c context.Context, ctx interface{}, conn *Conn, e
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	fmt.Fprintln(h, "[PostOpen]")
-	return nil
+	return err
 }
 
 func (h *loggingHook) prePrepare(c context.Context, stmt *Stmt) (interface{}, error) {
@@ -79,7 +79,7 @@ func (h *loggingHook) postPrepare(c context.Context, ctx interface{}, stmt *Stmt
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	fmt.Fprintln(h, "[PostPrepare]")
-	return nil
+	return err
 }
 
 func (h *loggingHook) preExec(c context.Context, stmt *Stmt, args []driver.NamedValue) (interface{}, error) {
@@ -100,7 +100,7 @@ func (h *loggingHook) postExec(c context.Context, ctx interface{}, stmt *Stmt, a
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	fmt.Fprintln(h, "[PostExec]")
-	return nil
+	return err
 }
 
 func (h *loggingHook) preQuery(c context.Context, stmt *Stmt, args []driver.NamedValue) (interface{}, error) {
@@ -121,7 +121,7 @@ func (h *loggingHook) postQuery(c context.Context, ctx interface{}, stmt *Stmt, 
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	fmt.Fprintln(h, "[PostQuery]")
-	return nil
+	return err
 }
 
 func (h *loggingHook) preBegin(c context.Context, conn *Conn) (interface{}, error) {
@@ -142,7 +142,7 @@ func (h *loggingHook) postBegin(c context.Context, ctx interface{}, conn *Conn, 
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	fmt.Fprintln(h, "[PostBegin]")
-	return nil
+	return err
 }
 
 func (h *loggingHook) preCommit(c context.Context, tx *Tx) (interface{}, error) {
@@ -163,7 +163,7 @@ func (h *loggingHook) postCommit(c context.Context, ctx interface{}, tx *Tx, err
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	fmt.Fprintln(h, "[PostCommit]")
-	return nil
+	return err
 }
 
 func (h *loggingHook) preRollback(c context.Context, tx *Tx) (interface{}, error) {
@@ -184,7 +184,7 @@ func (h *loggingHook) postRollback(c context.Context, ctx interface{}, tx *Tx, e
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	fmt.Fprintln(h, "[PostRollback]")
-	return nil
+	return err
 }
 
 func (h *loggingHook) preClose(c context.Context, conn *Conn) (interface{}, error) {
@@ -205,7 +205,7 @@ func (h *loggingHook) postClose(c context.Context, ctx interface{}, conn *Conn, 
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	fmt.Fprintln(h, "[PostClose]")
-	return nil
+	return err
 }
 
 func (h *loggingHook) preResetSession(c context.Context, conn *Conn) (interface{}, error) {
@@ -217,7 +217,7 @@ func (h *loggingHook) resetSession(c context.Context, ctx interface{}, conn *Con
 }
 
 func (h *loggingHook) postResetSession(c context.Context, ctx interface{}, conn *Conn, err error) error {
-	return nil
+	return err
 }
 
 func (h *loggingHook) preIsValid(conn *Conn) (interface{}, error) {


### PR DESCRIPTION
Hi Shogo,
As a proxy, I think it's a good idea and needed feature, be able to modify and/or discard the error returned by the DB driver.
With these changes, the only thing needed to keep the old behavior is to return the error received as a parameter in the "PostXXX" hooks,  otherwise, you'll be discarding the error.