### PR TITLE
drop support of Go 1.10

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,48 +28,36 @@ jobs:
           - "1.13"
           - "1.12"
           - "1.11"
-          - "1.10"
-          - "1.9"
-          - "1.8"
 
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
-        id: go
-      - run: |
-          go version
-          echo GOPATH="$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
-        shell: bash
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-        with:
-          path: src/github.com/shogo82148/go-sql-proxy
 
       - name: Test
         run: go test -v -coverprofile=coverage.txt .
-        env:
-          GO111MODULE: "on"
         shell: bash
-        working-directory: src/github.com/shogo82148/go-sql-proxy
 
       - name: Send coverage to coveralls.io
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.txt
           parallel: true
-          working-directory: src/github.com/shogo82148/go-sql-proxy
           flag-name: ${{ matrix.os }}-Go-${{ matrix.go }}
+
       - name: Send coverage to codecov.io
         uses: codecov/codecov-action@v3
         with:
           env_vars: OS,GO
-          root_dir: src/github.com/shogo82148/go-sql-proxy
+          root_dir: .
         env:
           OS: ${{ matrix.os }}
           GO: ${{ matrix.go }}
+
   finish:
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Go 1.10 doesn't work correctly on macOS-12.

https://github.com/shogo82148/go-sql-proxy/actions/runs/5631682904/job/15258883009

```
go tool compile: exit status 2
fatal error: runtime: bsdthread_register error

runtime stack:
runtime.throw(0x18268fc, 0x21)
	/usr/local/go/src/runtime/panic.go:616 +0x81 fp=0x7ff7bfefe318 sp=0x7ff7bfefe2f8 pc=0x1029101
runtime.goenvs()
	/usr/local/go/src/runtime/os_darwin.go:129 +0x83 fp=0x7ff7bfefe348 sp=0x7ff7bfefe318 pc=0x1026c83
runtime.schedinit()
	/usr/local/go/src/runtime/proc.go:501 +0xd6 fp=0x7ff7bfefe3b0 sp=0x7ff7bfefe348 pc=0x102b9f6
runtime.rt0_go(0x7ff7bfefe3e8, 0x2, 0x7ff7bfefe3e8, 0x0, 0x1000000, 0x2, 0x7ff7bfefe8a0, 0x7ff7bfefe8ea, 0x0, 0x7ff7bfefe8f2, ...)
	/usr/local/go/src/runtime/asm_amd64.s:252 +0x1f4 fp=0x7ff7bfefe3b8 sp=0x7ff7bfefe3b0 pc=0x1051a44
```