### PR TITLE
Fix Incorrect Nil Check in HooksContext.begin Method

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -509,7 +509,7 @@ func (h *HooksContext) preBegin(c context.Context, conn *Conn) (interface{}, err
 }
 
 func (h *HooksContext) begin(c context.Context, ctx interface{}, conn *Conn) error {
-	if h == nil || h.Open == nil {
+	if h == nil || h.Begin == nil {
 		return nil
 	}
 	return h.Begin(c, ctx, conn)


### PR DESCRIPTION
Thank you for this great library!

I've fixed what appears to be a typo-related bug. Previously, using hooks that only defined the Open method resulted in a nil pointer issue. This change corrects the nil check in the begin method from h.Open to h.Begin, resolving this problem.