### PR TITLE
add Go 1.27 to the test matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,7 @@ jobs:
           - macos-latest
         go:
           - "stable"
+          - "1.27"
           - "1.26"
           - "1.25"
           - "1.24"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Go 1.27 to the automated test coverage matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->